### PR TITLE
Users cannot register if there are missing details in the user registration form

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,9 +4,15 @@ class UsersController < ApplicationController
 
   def create
     user = User.new(user_params)
-    if user.save
+    if passwords_match? && user.save
       flash[:success] = "You are now registered and logged in!"
       redirect_to "/profile"
+    else
+      missing_params = user_params.select { |_, param| param.empty? }
+      missing_params = missing_params.keys.join(", ")
+      missing_params = "confirm password" if missing_params.empty?
+      flash[:failure] = "Please fill in the missing fields: #{missing_params}."
+      redirect_to "/register"
     end
   end
 
@@ -19,6 +25,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.permit(:name, :address, :city, :state, :zip, :email, :password) if passwords_match?
+    params.permit(:name, :address, :city, :state, :zip, :email, :password)
   end
 end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -8,7 +8,7 @@
 <%= label_tag :state, "State" %>
 <%= text_field_tag :state %>
 <%= label_tag :zip, "ZIP Code" %>
-<%= text_field_tag :zip %>
+<%= number_field_tag :zip %>
 <%= label_tag :email, "Email address" %>
 <%= text_field_tag :email %>
 <%= label_tag :password, "Password" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -12,8 +12,8 @@
 <%= label_tag :email, "Email address" %>
 <%= text_field_tag :email %>
 <%= label_tag :password, "Password" %>
-<%= text_field_tag :password %>
+<%= password_field_tag :password %>
 <%= label_tag :confirm_password, "Confirm Password" %>
-<%= text_field_tag :confirm_password %>
+<%= password_field_tag :confirm_password %>
 <%= submit_tag "Register as a New User" %>
 <% end %>

--- a/spec/features/users/new_user_registration_spec.rb
+++ b/spec/features/users/new_user_registration_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "New User Registration Spec" do
   before :each do
-    # @items = create_list(:item, 5)
+    @user = build(:user)
   end
 
   describe "As a visitor" do
@@ -16,14 +16,14 @@ RSpec.describe "New User Registration Spec" do
 
         expect(User.all.count).to eq(0)
 
-        fill_in :name, with: "AJ"
-        fill_in :address, with: "Cool Street"
-        fill_in :city, with: "Denver"
-        fill_in :state, with: "CO"
-        fill_in :zip, with: 80239
-        fill_in :email, with: "my_email@email.com"
-        fill_in :password, with: "my_password"
-        fill_in :confirm_password, with: "my_password"
+        fill_in :name, with: @user.name
+        fill_in :address, with: @user.address
+        fill_in :city, with: @user.city
+        fill_in :state, with: @user.state
+        fill_in :zip, with: @user.zip
+        fill_in :email, with: @user.email
+        fill_in :password, with: @user.password
+        fill_in :confirm_password, with: @user.password
 
         click_button "Register as a New User"
 

--- a/spec/features/users/new_user_registration_validation_spec.rb
+++ b/spec/features/users/new_user_registration_validation_spec.rb
@@ -1,0 +1,201 @@
+require "rails_helper"
+
+RSpec.describe "New User Registration Validation Spec" do
+  before :each do
+    @user = build(:user)
+
+    expect(User.all.count).to eq(0)
+
+    visit "/register"
+  end
+
+  describe "As a visitor" do
+    describe "When I visit the user registration page" do
+      describe "I cannot register if I do not fill out the" do
+        it "name field" do
+
+            fill_in :address, with: @user.address
+            fill_in :city, with: @user.city
+            fill_in :state, with: @user.state
+            fill_in :zip, with: @user.zip
+            fill_in :email, with: @user.email
+            fill_in :password, with: @user.password
+            fill_in :confirm_password, with: @user.password
+
+            click_button "Register as a New User"
+
+            expect(User.all.count).to eq(0)
+
+            expect(current_path).to eq("/register")
+            expect(page).to have_content("Please fill in the missing fields: name.")
+          end
+
+        it "address field" do
+          fill_in :name, with: @user.name
+
+          fill_in :city, with: @user.city
+          fill_in :state, with: @user.state
+          fill_in :zip, with: @user.zip
+          fill_in :email, with: @user.email
+          fill_in :password, with: @user.password
+          fill_in :confirm_password, with: @user.password
+
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: address.")
+        end
+
+        it "city field" do
+          fill_in :name, with: @user.name
+          fill_in :address, with: @user.address
+
+          fill_in :state, with: @user.state
+          fill_in :zip, with: @user.zip
+          fill_in :email, with: @user.email
+          fill_in :password, with: @user.password
+          fill_in :confirm_password, with: @user.password
+
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: city.")
+        end
+
+        it "state field" do
+          fill_in :name, with: @user.name
+          fill_in :address, with: @user.address
+          fill_in :city, with: @user.city
+
+          fill_in :zip, with: @user.zip
+          fill_in :email, with: @user.email
+          fill_in :password, with: @user.password
+          fill_in :confirm_password, with: @user.password
+
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: state.")
+        end
+
+        it "zip field" do
+          fill_in :name, with: @user.name
+          fill_in :address, with: @user.address
+          fill_in :city, with: @user.city
+          fill_in :state, with: @user.state
+
+          fill_in :email, with: @user.email
+          fill_in :password, with: @user.password
+          fill_in :confirm_password, with: @user.password
+
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: zip.")
+        end
+
+        it "email field" do
+          fill_in :name, with: @user.name
+          fill_in :address, with: @user.address
+          fill_in :city, with: @user.city
+          fill_in :state, with: @user.state
+          fill_in :zip, with: @user.zip
+
+          fill_in :password, with: @user.password
+          fill_in :confirm_password, with: @user.password
+
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: email.")
+        end
+
+        it "a combination of fields" do
+          fill_in :name, with: @user.name
+          fill_in :address, with: @user.address
+          fill_in :city, with: @user.city
+
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: state, zip, email, password.")
+        end
+
+        it "all fields" do
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: name, address, city, state, zip, email, password.")
+        end
+
+
+        it "password field" do
+          fill_in :name, with: @user.name
+          fill_in :address, with: @user.address
+          fill_in :city, with: @user.city
+          fill_in :state, with: @user.state
+          fill_in :zip, with: @user.zip
+          fill_in :email, with: @user.email
+
+          fill_in :confirm_password, with: @user.password
+
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: password.")
+        end
+
+        it "confirm password field" do
+          fill_in :name, with: @user.name
+          fill_in :address, with: @user.address
+          fill_in :city, with: @user.city
+          fill_in :state, with: @user.state
+          fill_in :zip, with: @user.zip
+          fill_in :email, with: @user.email
+          fill_in :password, with: @user.password
+
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: confirm password.")
+        end
+
+        it "password and confirm password field must be the same password" do
+          fill_in :name, with: @user.name
+          fill_in :address, with: @user.address
+          fill_in :city, with: @user.city
+          fill_in :state, with: @user.state
+          fill_in :zip, with: @user.zip
+          fill_in :email, with: @user.email
+          fill_in :password, with: @user.password
+          fill_in :confirm_password, with: "not_the_password"
+
+          click_button "Register as a New User"
+
+          expect(User.all.count).to eq(0)
+
+          expect(current_path).to eq("/register")
+          expect(page).to have_content("Please fill in the missing fields: confirm password.")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The spec covers cases where a user fails to:
- Fill out any single field
- Fill out a combination of fields
- Confirm their password with a matching password

Implementation details:

- There is now a sad path for User#create
- Passwords have to be checked for matching before checking user.save
-- Otherwise, user.save will create a record in the database

- The new user registration form now uses a number_field_tag
-- This design implementation will prevent edge-cases where:
-- A user can enter a non-number as a Zip Code
