### PR TITLE
Log out (RR)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,7 +26,7 @@ class SessionsController < ApplicationController
         redirect_to '/admin/dashboard'
       end
     else
-      flash[error] = 'Wrong email or password entered - please try logging in again.'
+      flash[:error] = 'Wrong email or password entered - please try logging in again.'
       render :new
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,8 +26,12 @@ class SessionsController < ApplicationController
         redirect_to '/admin/dashboard'
       end
     else
-      flash[:error] = 'Wrong email or password entered - please try logging in again.'
+      flash[error] = 'Wrong email or password entered - please try logging in again.'
       render :new
     end
+  end
+
+  def destroy
+    redirect_to '/'
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -32,6 +32,9 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    session.delete(:user_id)
+    session.delete(:cart)
+    flash[:success] = "You have logged out."
     redirect_to '/'
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,0 +1,3 @@
+class WelcomeController < ApplicationController
+
+end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,3 +1,5 @@
 class WelcomeController < ApplicationController
+  def index
 
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root to: "welcome#index"
 
   get "/merchants", to: "merchants#index"
   get "/merchants/new", to: "merchants#new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
   get "/logout", to: "sessions#destroy"
+  # this is a GET verb bc the user story says the user *visits* the path, not clicks on it
 
   namespace :admin do
     get "/dashboard", to: "dashboard#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
 
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
+  get "/logout", to: "sessions#destroy"
 
   namespace :admin do
     get "/dashboard", to: "dashboard#index"

--- a/spec/features/users/logout_spec.rb
+++ b/spec/features/users/logout_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe 'User can log out' do
       user = create(:user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
+      item = create(:item)
+      visit "/items/#{item.id}"
+      click_on "Add To Cart"
+      within('.topnav') do
+        expect(page).to have_content("Cart: 1")
+      end
+
       visit '/logout'
       expect(current_path).to eq('/')
       expect(page).to have_content("You have been logged out.")

--- a/spec/features/users/logout_spec.rb
+++ b/spec/features/users/logout_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'User can log out' do
+  describe "When I visit the logout path" do
+    it "I am redirected to the site's home page, I see a flash message indicating I'm logged out, and my shopping cart is emptied" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/logout'
+      expect(current_path).to eq('/')
+      expect(page).to have_content("You have been logged out.")
+      within('.topnav') do
+        expect(page).to have_content("Cart: 0")
+      end
+    end
+  end
+end

--- a/spec/features/users/logout_spec.rb
+++ b/spec/features/users/logout_spec.rb
@@ -19,12 +19,6 @@ RSpec.describe 'User can log out' do
       within('.topnav') do
         expect(page).to have_content("Cart: 0")
       end
-
-      # add expectation to confirm that @current_user does not exist anymore
     end
   end
 end
-
-
-# log in button should not exist when someone's logged in - take care of this in view logic
-# if someone were to type in the login url path, they should be redirected like

--- a/spec/features/users/logout_spec.rb
+++ b/spec/features/users/logout_spec.rb
@@ -15,10 +15,16 @@ RSpec.describe 'User can log out' do
 
       visit '/logout'
       expect(current_path).to eq('/')
-      expect(page).to have_content("You have been logged out.")
+      expect(page).to have_content("You have logged out.")
       within('.topnav') do
         expect(page).to have_content("Cart: 0")
       end
+
+      # add expectation to confirm that @current_user does not exist anymore
     end
   end
 end
+
+
+# log in button should not exist when someone's logged in - take care of this in view logic
+# if someone were to type in the login url path, they should be redirected like


### PR DESCRIPTION
Addresses user story 16 / issue #20 
• A user can visit a `/logout` path in order to sign out of their session. This also deletes anything remaining in the user's cart.
• There is now a `WelcomeController` and an empty root path view so that when a user logs out they can be redirected to `/` as described by the user story. @judithpillado this might impact your code; let me know if you'd like to connect about this or if you've already implemented a home page/root route, in which case I'm happy to adjust this code.

Some notes about this PR:
• I wonder if there's a way to confirm that `@current_user` does not exist anymore in `logout_spec.rb`?
• The current implementation of this feature involves the user _visiting_ `/logout` and not clicking on a logout button. The plan is that once the navigation bar feature branch is complete, I'll merge that code into this `login_logout` feature branch and update this logout route and its verb accordingly.
• When ^^ that happens, need to confirm that the log in button doesn't exist when a user is already logged in (impacts earlier user stories related to this feature branch)