### PR TITLE
Lito items dev

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,7 @@ class ItemsController<ApplicationController
       @merchant = Merchant.find(params[:merchant_id])
       @items = @merchant.items
     else
-      @items = Item.all
+      @items = Item.active_items
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,9 @@ class Item <ApplicationRecord
                         :inventory
   validates_inclusion_of :active?, :in => [true, false]
   scope :active_items, -> {where(active?: true)}
-  #scope :total_quantity, ->
+  scope :join_with_item_orders, -> { joins(:item_orders) }
+  scope :group_by_quantity, -> { select("items.*, sum(quantity) as order_quantity").group(:id) }
+
   validates_numericality_of :price, greater_than: 0
 
   def average_review
@@ -26,21 +28,15 @@ class Item <ApplicationRecord
     item_orders.empty?
   end
 
-  def self.least_popular
-    sorted_by_quantity.map {|item|  "#{item.name}: #{item.total_sold}"}[0..4]
-  end
-
-  def self.most_popular
-    sorted_by_quantity.map {|item|  "#{item.name}: #{item.total_sold}"}[-5..-1].reverse
-  end
-
   def total_sold
     item_orders.sum(:quantity)
   end
 
-  private
+  def self.most_popular_list
+    join_with_item_orders.group_by_quantity.order("order_quantity DESC").limit(5)
+  end
 
-  def self.sorted_by_quantity
-    joins(:item_orders).select("items.*, sum(quantity) as order_quantity").group(:id).order("order_quantity")
+  def self.least_popular_list
+    join_with_item_orders.group_by_quantity.order("order_quantity").limit(5)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,6 +10,7 @@ class Item <ApplicationRecord
                         :image,
                         :inventory
   validates_inclusion_of :active?, :in => [true, false]
+  scope :active_items, -> {where(active?: true)}
   validates_numericality_of :price, greater_than: 0
 
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,8 +11,8 @@ class Item <ApplicationRecord
                         :inventory
   validates_inclusion_of :active?, :in => [true, false]
   scope :active_items, -> {where(active?: true)}
+  #scope :total_quantity, ->
   validates_numericality_of :price, greater_than: 0
-
 
   def average_review
     reviews.average(:rating)
@@ -26,4 +26,21 @@ class Item <ApplicationRecord
     item_orders.empty?
   end
 
+  def self.least_popular
+    sorted_by_quantity.map {|item|  "#{item.name}: #{item.total_sold}"}[0..4]
+  end
+
+  def self.most_popular
+    sorted_by_quantity.map {|item|  "#{item.name}: #{item.total_sold}"}[-5..-1].reverse
+  end
+
+  def total_sold
+    item_orders.sum(:quantity)
+  end
+
+  private
+
+  def self.sorted_by_quantity
+    joins(:item_orders).select("items.*, sum(quantity) as order_quantity").group(:id).order("order_quantity")
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -9,7 +9,11 @@
     <section class = "grid-item" id= 'item-<%=item.id%>'>
       <h2> <%=link_to item.name, "/items/#{item.id}" %> </h2>
       <p>Sold by: <%=link_to item.merchant.name, "/merchants/#{item.merchant.id}" %></p>
-      <img src= <%= item.image %>>
+
+      <a href="/items/<%=item.id%>" id="<%=item.id%>">
+        <img  src= <%= item.image %>>
+      </a>
+
       <p> <%= item.description unless @merchant%> </p>
       <p>Price: <%=number_to_currency(item.price) %> </p>
       <p>Inventory: <%= item.inventory %> </p>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -9,11 +9,9 @@
     <section class = "grid-item" id= 'item-<%=item.id%>'>
       <h2> <%=link_to item.name, "/items/#{item.id}" %> </h2>
       <p>Sold by: <%=link_to item.merchant.name, "/merchants/#{item.merchant.id}" %></p>
-
       <a href="/items/<%=item.id%>" id="<%=item.id%>">
         <img  src= <%= item.image %>>
       </a>
-
       <p> <%= item.description unless @merchant%> </p>
       <p>Price: <%=number_to_currency(item.price) %> </p>
       <p>Inventory: <%= item.inventory %> </p>
@@ -27,3 +25,33 @@
     </section>
     <% end %>
 </section>
+
+<section class="most_popular">
+<table style="width:30%">
+  <tr>
+    <th>Most Popular Items</th>
+    <th>Quantity Sold</th>
+  </tr>
+  <% @items.most_popular_list.each do |popular_item|%>
+    <tr>
+      <td><%= popular_item.name %></td>
+      <td><%= popular_item.total_sold %></td>
+    </tr>
+  <% end %>
+</table>
+</section>
+
+<section class="least_popular">
+  <table style="width:30%">
+    <tr>
+      <th>Least Popular Items</th>
+      <th>Quantity Sold</th>
+    </tr>
+    <% @items.least_popular_list.each do |popular_item|%>
+      <tr>
+        <td><%= popular_item.name %></td>
+        <td><%= popular_item.total_sold %></td>
+      </tr>
+    <% end %>
+  </table>
+  </section>

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe "Items Index Page" do
       expect(page).to have_link(@tire.merchant.name)
       expect(page).to have_link(@pull_toy.name)
       expect(page).to have_link(@pull_toy.merchant.name)
-      expect(page).to have_link(@dog_bone.name)
-      expect(page).to have_link(@dog_bone.merchant.name)
+
     end
 
     it "I can see a list of all of the items "do
@@ -46,16 +45,41 @@ RSpec.describe "Items Index Page" do
         expect(page).to have_link(@brian.name)
         expect(page).to have_css("img[src*='#{@pull_toy.image}']")
       end
+    end
 
-      within "#item-#{@dog_bone.id}" do
-        expect(page).to have_link(@dog_bone.name)
-        expect(page).to have_content(@dog_bone.description)
-        expect(page).to have_content("Price: $#{@dog_bone.price}")
-        expect(page).to have_content("Inactive")
-        expect(page).to have_content("Inventory: #{@dog_bone.inventory}")
+    it "disabled items are not shown on the index page "do
+
+      @handlebar = @meg.items.create(name: "Handle Bar", description: "Good luck steering without it!", price: 200, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 15, active?: false)
+
+      visit '/items'
+
+      expect(page).to_not have_content(@handlebar.name)
+      expect(page).to_not have_content(@handlebar.description)
+      expect(page).to_not have_content(@handlebar.price)
+      expect(page).to_not have_content(@handlebar.inventory)
+
+      expect(page).to_not have_content(@dog_bone.name)
+
+      within "#item-#{@tire.id}" do
+        expect(page).to have_link(@tire.name)
+        expect(page).to have_content(@tire.description)
+        expect(page).to have_content("Price: $#{@tire.price}")
+        expect(page).to have_content("Active")
+        expect(page).to have_content("Inventory: #{@tire.inventory}")
+        expect(page).to have_link(@meg.name)
+        expect(page).to have_css("img[src*='#{@tire.image}']")
+      end
+
+      within "#item-#{@pull_toy.id}" do
+        expect(page).to have_link(@pull_toy.name)
+        expect(page).to have_content(@pull_toy.description)
+        expect(page).to have_content("Price: $#{@pull_toy.price}")
+        expect(page).to have_content("Active")
+        expect(page).to have_content("Inventory: #{@pull_toy.inventory}")
         expect(page).to have_link(@brian.name)
-        expect(page).to have_css("img[src*='#{@dog_bone.image}']")
+        expect(page).to have_css("img[src*='#{@pull_toy.image}']")
       end
     end
+
   end
 end

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -81,5 +81,12 @@ RSpec.describe "Items Index Page" do
       end
     end
 
+    it 'item images are links to the item show page' do
+      visit '/items'
+
+      find("##{@tire.id}").click
+      expect(current_path).to eq("/items/#{@tire.id}")
+    end
+
   end
 end

--- a/spec/features/items/item_stats_spec.rb
+++ b/spec/features/items/item_stats_spec.rb
@@ -1,0 +1,1 @@
+require 'rails_helper'

--- a/spec/features/items/item_stats_spec.rb
+++ b/spec/features/items/item_stats_spec.rb
@@ -1,1 +1,67 @@
 require 'rails_helper'
+
+RSpec.describe 'As a user' do
+  describe 'when I visit the items index page' do
+    describe "I see statistics for all items" do
+      before(:each) do
+        @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+
+        @item1 = create(:item, merchant_id: @bike_shop.id)
+        @item2 = create(:item, merchant_id: @bike_shop.id)
+        @item3 = create(:item, merchant_id: @bike_shop.id)
+        @item4 = create(:item, merchant_id: @bike_shop.id)
+        @item5 = create(:item, merchant_id: @bike_shop.id)
+        @item6 = create(:item, merchant_id: @bike_shop.id)
+        @item7 = create(:item, merchant_id: @bike_shop.id)
+        @item8 = create(:item, merchant_id: @bike_shop.id)
+        @item9 = create(:item, merchant_id: @bike_shop.id)
+        @item10 = create(:item, merchant_id: @bike_shop.id)
+
+        order = create(:order)
+
+        order.item_orders.create(item: @item1, price: 5, quantity: 1)
+        order.item_orders.create(item: @item2, price: 5, quantity: 2)
+        order.item_orders.create(item: @item3, price: 5, quantity: 3)
+        order.item_orders.create(item: @item4, price: 5, quantity: 4)
+        order.item_orders.create(item: @item5, price: 5, quantity: 5)
+        order.item_orders.create(item: @item6, price: 5, quantity: 6)
+        order.item_orders.create(item: @item7, price: 5, quantity: 7)
+        order.item_orders.create(item: @item8, price: 5, quantity: 8)
+        order.item_orders.create(item: @item9, price: 5, quantity: 9)
+        order.item_orders.create(item: @item10, price: 5, quantity: 10)
+      end
+
+      it 'shows the top 5 most popular items by quantity purchased, plus the quantity bought' do
+
+        visit "/items"
+        within ".least_popular" do
+          expect(page).to have_content("Least Popular Items")
+          expect(page).to have_content(@item1.name)
+          expect(page).to have_content(@item1.total_sold)
+          expect(page).to have_content(@item2.name)
+          expect(page).to have_content(@item2.total_sold)
+          expect(page).to have_content(@item3.name)
+          expect(page).to have_content(@item3.total_sold)
+          expect(page).to have_content(@item4.name)
+          expect(page).to have_content(@item4.total_sold)
+          expect(page).to have_content(@item5.name)
+          expect(page).to have_content(@item5.total_sold)
+        end
+
+        within ".most_popular" do
+          expect(page).to have_content("Most Popular Items")
+          expect(page).to have_content(@item10.name)
+          expect(page).to have_content(@item10.total_sold)
+          expect(page).to have_content(@item9.name)
+          expect(page).to have_content(@item9.total_sold)
+          expect(page).to have_content(@item8.name)
+          expect(page).to have_content(@item8.total_sold)
+          expect(page).to have_content(@item7.name)
+          expect(page).to have_content(@item7.total_sold)
+          expect(page).to have_content(@item6.name)
+          expect(page).to have_content(@item6.total_sold)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -47,5 +47,51 @@ describe Item, type: :model do
       order.item_orders.create(item: @chain, price: @chain.price, quantity: 2)
       expect(@chain.no_orders?).to eq(false)
     end
+
+    it 'item_quantity' do
+      @item1 = create(:item, merchant_id: @bike_shop.id)
+      order = create(:order)
+      order.item_orders.create(item: @item1, price: 5, quantity: 1)
+
+      expect(@item1.total_sold).to eq(1)
+    end
   end
-end
+
+  describe 'class methods' do
+    before(:each) do
+      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+
+      @item1 = create(:item, merchant_id: @bike_shop.id)
+      @item2 = create(:item, merchant_id: @bike_shop.id)
+      @item3 = create(:item, merchant_id: @bike_shop.id)
+      @item4 = create(:item, merchant_id: @bike_shop.id)
+      @item5 = create(:item, merchant_id: @bike_shop.id)
+      @item6 = create(:item, merchant_id: @bike_shop.id)
+      @item7 = create(:item, merchant_id: @bike_shop.id)
+      @item8 = create(:item, merchant_id: @bike_shop.id)
+      @item9 = create(:item, merchant_id: @bike_shop.id)
+      @item10 = create(:item, merchant_id: @bike_shop.id)
+
+      order = create(:order)
+
+      order.item_orders.create(item: @item1, price: 5, quantity: 1)
+      order.item_orders.create(item: @item2, price: 5, quantity: 2)
+      order.item_orders.create(item: @item3, price: 5, quantity: 3)
+      order.item_orders.create(item: @item4, price: 5, quantity: 4)
+      order.item_orders.create(item: @item5, price: 5, quantity: 5)
+      order.item_orders.create(item: @item6, price: 5, quantity: 6)
+      order.item_orders.create(item: @item7, price: 5, quantity: 7)
+      order.item_orders.create(item: @item8, price: 5, quantity: 8)
+      order.item_orders.create(item: @item9, price: 5, quantity: 9)
+      order.item_orders.create(item: @item10, price: 5, quantity: 10)
+    end
+
+    it '.least_popular' do
+      expect(Item.least_popular).to eq(["#{@item1.name}: #{@item1.total_sold}","#{@item2.name}: #{@item2.total_sold}","#{@item3.name}: #{@item3.total_sold}","#{@item4.name}: #{@item4.total_sold}","#{@item5.name}: #{@item5.total_sold}"])
+    end
+
+    it '.most_popular' do
+      expect(Item.most_popular).to eq(["#{@item10.name}: #{@item10.total_sold}","#{@item9.name}: #{@item9.total_sold}","#{@item8.name}: #{@item8.total_sold}","#{@item7.name}: #{@item7.total_sold}","#{@item6.name}: #{@item6.total_sold}"])
+    end
+    end
+  end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -48,7 +48,7 @@ describe Item, type: :model do
       expect(@chain.no_orders?).to eq(false)
     end
 
-    it 'item_quantity' do
+    it 'total_sold' do
       @item1 = create(:item, merchant_id: @bike_shop.id)
       order = create(:order)
       order.item_orders.create(item: @item1, price: 5, quantity: 1)
@@ -86,12 +86,12 @@ describe Item, type: :model do
       order.item_orders.create(item: @item10, price: 5, quantity: 10)
     end
 
-    it '.least_popular' do
-      expect(Item.least_popular).to eq(["#{@item1.name}: #{@item1.total_sold}","#{@item2.name}: #{@item2.total_sold}","#{@item3.name}: #{@item3.total_sold}","#{@item4.name}: #{@item4.total_sold}","#{@item5.name}: #{@item5.total_sold}"])
+    it '.least_popular_list' do
+      expect(Item.least_popular_list).to eq([@item1, @item2, @item3, @item4, @item5])
     end
 
-    it '.most_popular' do
-      expect(Item.most_popular).to eq(["#{@item10.name}: #{@item10.total_sold}","#{@item9.name}: #{@item9.total_sold}","#{@item8.name}: #{@item8.total_sold}","#{@item7.name}: #{@item7.total_sold}","#{@item6.name}: #{@item6.total_sold}"])
+    it '.most_popular_list' do
+      expect(Item.most_popular_list).to eq([@item10, @item9, @item8, @item7, @item6])
     end
     end
   end


### PR DESCRIPTION
User story 17 and 18. 

17: Item index shows active items only, and image is a link to show page
1) Don't show disabled posts. Update item controller index logic to send only active items to the index page for display. The logic is in the item controller as method active_items 
2) Link image to item show page. The image is wrapped in an href link. 

18: Item Statistics (most/least popular)
Added AR queries class methods to the model, along with an instance model to find total_quantity sold. The class methods are broken down into scopes. This isn't required, but it might allow us to DRY future code. 