### PR TITLE
Fix bug: new users are now logged in automatically after they register.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,6 +35,7 @@ class UsersController < ApplicationController
 
   def register(user)
     user.save
+    session[:user_id] = user.id
     flash[:success] = "You are now registered and logged in!"
     redirect_to "/profile"
   end

--- a/spec/features/users/new_user_registration_spec.rb
+++ b/spec/features/users/new_user_registration_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "New User Registration Spec" do
         expect(current_path).to eq("/profile")
 
         expect(page).to have_content("You are now registered and logged in!")
+        expect(page).to_not have_content("The page you were looking for doesn't exist.")
       end
     end
   end


### PR DESCRIPTION
When the User Registration was implemented, users were directed to `"/profile"` without being logged in.

![Screen Shot 2020-07-25 at 5 23 44 PM](https://user-images.githubusercontent.com/31839316/88468382-fabc7c80-ce9f-11ea-8c36-c92290efca0f.png)

Image description: Screenshot of the profile page after a user submits a new registration. There is a 404 error.

I modified the spec to NOT expect a 404 error (the profile stories are still being implemented, so the strategy is to "test around").
If a user does not see a 404 error after registering - it means they were logged in.