### PR TITLE
Update Order model to enum status

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,6 +5,8 @@ class Order <ApplicationRecord
   has_many :item_orders
   has_many :items, through: :item_orders
 
+  enum status: [:pending, :packaged, :shipped, :cancelled]
+
   def grandtotal
     item_orders.sum('price * quantity')
   end

--- a/db/migrate/20200725190102_add_status_to_orders.rb
+++ b/db/migrate/20200725190102_add_status_to_orders.rb
@@ -1,5 +1,5 @@
 class AddStatusToOrders < ActiveRecord::Migration[5.1]
   def change
-    add_column :orders, :status, :string, default: "pending"
+    add_column :orders, :status, :integer, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20200725194353) do
     t.integer "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status", default: "pending"
+    t.integer "status", default: 0
     t.bigint "user_id"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -16,6 +16,32 @@ describe Order, type: :model do
     it {should have_many(:items).through(:item_orders)}
   end
 
+  describe "status" do
+    it "can be pending" do
+      order = create(:order, status: 0)
+      expect(order.status).to eq("pending")
+      expect(order.pending?).to be_truthy
+    end
+
+    it "can be packaged" do
+      order = create(:order, status: 1)
+      expect(order.status).to eq("packaged")
+      expect(order.packaged?).to be_truthy
+    end
+
+    it "can be shipped" do
+      order = create(:order, status: 2)
+      expect(order.status).to eq("shipped")
+      expect(order.shipped?).to be_truthy
+    end
+
+    it "can be cancelled" do
+      order = create(:order, status: 3)
+      expect(order.status).to eq("cancelled")
+      expect(order.cancelled?).to be_truthy
+    end
+  end
+
   describe 'instance methods' do
     before :each do
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)


### PR DESCRIPTION
### Order Migration edited

The status column is now an integer. Orders are made with a default of 0.

0 - pending
1 - packaged
2 - shipped
3 - cancelled

### Make sure to re-run migrations once this is merged.
