### PR TITLE
Adds Order Cancellation

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,14 +3,6 @@ class OrdersController <ApplicationController
   def new
   end
 
-  def update
-    order = Order.find(params[:id])
-    order.cancel
-    order.save
-    flash[:cancelled] = "The order is now cancelled"
-    redirect_to "/profile"
-  end
-
   def show
     @order = Order.find(params[:id])
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,6 +3,14 @@ class OrdersController <ApplicationController
   def new
   end
 
+  def update
+    order = Order.find(params[:id])
+    order.cancel
+    order.save
+    flash[:cancelled] = "The order is now cancelled"
+    redirect_to "/profile"
+  end
+
   def show
     @order = Order.find(params[:id])
   end

--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -3,4 +3,13 @@ class Profile::OrdersController < ApplicationController
   def show
     @order = Order.find(params[:order_id])
   end
+
+  def update
+    order = Order.find(params[:order_id])
+    order.cancel
+    order.save
+    flash[:cancelled] = "The order is now cancelled"
+    redirect_to "/profile"
+  end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -32,6 +32,16 @@ class Item <ApplicationRecord
     item_orders.sum(:quantity)
   end
 
+  def sell(amount_of_items)
+    new_amount = self.inventory -= amount_of_items
+    update(inventory: new_amount)
+  end
+
+  def restock(amount_of_items)
+    new_amount = self.inventory += amount_of_items
+    update(inventory: new_amount)
+  end
+
   def self.most_popular_list
     join_with_item_orders.group_by_quantity.order("order_quantity DESC").limit(5)
   end

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -1,8 +1,11 @@
 class ItemOrder <ApplicationRecord
-  validates_presence_of :item_id, :order_id, :price, :quantity
+  validates_presence_of :item_id, :order_id, :price, :quantity, :status
 
   belongs_to :item
   belongs_to :order
+
+  enum status: [:unfulfilled, :fulfilled]
+
 
   def subtotal
     price * quantity

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -6,8 +6,17 @@ class ItemOrder <ApplicationRecord
 
   enum status: [:unfulfilled, :fulfilled]
 
-
   def subtotal
     price * quantity
+  end
+
+  def fulfill
+    item.sell(quantity)
+    update(status: "fulfilled")
+  end
+
+  def unfulfill
+    item.restock(quantity)
+    update(status: "unfulfilled")
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -10,4 +10,11 @@ class Order <ApplicationRecord
   def grandtotal
     item_orders.sum('price * quantity')
   end
+
+  def cancel
+    self.item_orders.each do |item_order|
+      item_order.unfulfill if item_order.fulfilled?
+    end
+    self.update(status: "cancelled")
+  end
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -47,3 +47,5 @@
 <section id="datecreated">
   <p> <%= @order.created_at%></p>
 </section>
+
+<%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %>

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -22,3 +22,5 @@
 </ul>
 <% end %>
 </section>
+
+<%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,10 +43,6 @@ Rails.application.routes.draw do
   get "/profile", to: "users#show"
   get "/profile/orders", to: "orders#index"
 
-  # placeholder until story 29 is finished
-  get "/profile/orders/:id", to: "orders#show"
-  patch "/profile/orders/:id", to: "orders#update"
-
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"
@@ -61,6 +57,7 @@ Rails.application.routes.draw do
 
   namespace :profile do
     get "/orders/:order_id", to: "orders#show"
+    patch "/orders/:order_id", to: "orders#update"
   end
 
   get "/admin", to: "admin/dashboard#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,10 @@ Rails.application.routes.draw do
   get "/profile", to: "users#show"
   get "/profile/orders", to: "orders#index"
 
+  # placeholder until story 29 is finished
+  get "/profile/orders/:id", to: "orders#show"
+  patch "/profile/orders/:id", to: "orders#update"
+
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"

--- a/db/migrate/20200726020323_add_status_to_item_orders.rb
+++ b/db/migrate/20200726020323_add_status_to_item_orders.rb
@@ -1,0 +1,5 @@
+class AddStatusToItemOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :item_orders, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200725194353) do
+ActiveRecord::Schema.define(version: 20200726020323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20200725194353) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["item_id"], name: "index_item_orders_on_item_id"
     t.index ["order_id"], name: "index_item_orders_on_order_id"
   end

--- a/spec/features/orders/cancellation_spec.rb
+++ b/spec/features/orders/cancellation_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Order Cancellation Spec" do
+  before :each do
+    @merchant1 = create(:merchant)
+    @gizmos = create(:item, merchant: @merchant1, name: "Gizmos", price: 10, inventory: 10)
+
+    @merchant2 = create(:merchant)
+    @doodads = create(:item, merchant: @merchant2, name: "Doo Dads", price: 12, inventory: 5)
+
+    @customer = create(:user)
+    @order = create(:order, user: @customer)
+    @order.item_orders.create(item: @gizmos, price: @gizmos.price, quantity: 3, status: 0)
+    @order.item_orders.create(item: @doodads, price: @doodads.price, quantity: 2, status: 1)
+
+    visit login_path
+    fill_in :email, with: @customer.email
+    fill_in :password, with: @customer.password
+    click_button 'Log In'
+
+    visit "/profile/orders/#{@order.id}"
+  end
+
+  describe "As a registered user" do
+    describe "When I visit an order's show page, I can cancel an order" do
+      it "I see a button or link to cancel the order" do
+        expect(page).to have_button("Cancel Order")
+      end
+    end
+
+    describe "The following happens when I click the cancel button" do
+      it "Each row in the 'order items' table is given a status of 'unfulfilled'" do
+        click_button "Cancel Order"
+        expect(Order.all.first.item_orders.all?(&:unfulfilled?)).to be_truthy
+      end
+
+      it "The order itself is given a status of 'cancelled'" do
+        click_button "Cancel Order"
+        expect(Order.all.first.status).to eq("cancelled")
+        expect(Order.all.first.cancelled?).to be_truthy
+      end
+
+      it "Merchants restock their inventory with previously fulfilled items" do
+        expect(Item.find(@doodads.id).inventory).to eq(5)
+        click_button "Cancel Order"
+        expect(Item.find(@doodads.id).inventory).to eq(7)
+      end
+
+      it "I am returned to my profile page and to see the order updated" do
+        click_button "Cancel Order"
+        expect(current_path).to eq("/profile")
+        expect(page).to have_content("The order is now cancelled")
+
+        visit "/profile/orders"
+        within "section.order-#{@order.id}" do
+          expect(page).to have_content("Status: cancelled")
+        end
+      end
+    end
+  end
+end

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -6,11 +6,33 @@ describe ItemOrder, type: :model do
     it { should validate_presence_of :item_id }
     it { should validate_presence_of :price }
     it { should validate_presence_of :quantity }
+    it { should validate_presence_of :status }
   end
 
   describe "relationships" do
     it {should belong_to :item}
     it {should belong_to :order}
+  end
+
+  describe "status" do
+    before :each do
+      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      customer = create(:user)
+      order_1 = customer.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      @unfulfilled_item_order = order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2, status: 0)
+      @fulfilled_item_order = order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2, status: 1)
+    end
+
+    it "can be unfulfilled" do
+      expect(@unfulfilled_item_order.status).to eq("unfulfilled")
+      expect(@unfulfilled_item_order.unfulfilled?).to be_truthy
+    end
+
+    it "can be fulfilled" do
+      expect(@fulfilled_item_order.status).to eq("fulfilled")
+      expect(@fulfilled_item_order.fulfilled?).to be_truthy
+    end
   end
 
   describe 'instance methods' do

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -36,14 +36,36 @@ describe ItemOrder, type: :model do
   end
 
   describe 'instance methods' do
-    it 'subtotal' do
-      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      customer = create(:user)
-      order_1 = customer.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
-      item_order_1 = order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2)
+    before :each do
+      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @customer = create(:user)
+      @order_1 = @customer.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      @item_order_1 = @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
+    end
 
-      expect(item_order_1.subtotal).to eq(200)
+    it 'subtotal' do
+      expect(@item_order_1.subtotal).to eq(200)
+    end
+
+    it "fulfill" do
+      expect(@tire.inventory).to eq(12)
+      expect(@item_order_1.status).to eq("unfulfilled")
+
+      @item_order_1.fulfill
+      expect(@tire.inventory).to eq(10)
+      expect(@item_order_1.status).to eq("fulfilled")
+    end
+
+    it "unfulfill" do
+      expect(@tire.inventory).to eq(12)
+
+      @item_order_1.fulfill
+      expect(@tire.inventory).to eq(10)
+
+      @item_order_1.unfulfill
+      expect(@tire.inventory).to eq(12)
+      expect(@item_order_1.status).to eq("unfulfilled")
     end
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -56,6 +56,18 @@ describe Item, type: :model do
 
       expect(@item1.total_sold).to eq(1)
     end
+
+    it "sell" do
+      @item1 = create(:item, inventory: 5)
+      @item1.sell(2)
+      expect(@item1.inventory).to eq(3)
+    end
+
+    it "restock" do
+      @item1 = create(:item, inventory: 3)
+      @item1.restock(2)
+      expect(@item1.inventory).to eq(5)
+    end
   end
 
   describe 'class methods' do
@@ -94,5 +106,5 @@ describe Item, type: :model do
     it '.most_popular_list' do
       expect(Item.most_popular_list).to eq([@item10, @item9, @item8, @item7, @item6])
     end
-    end
   end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -54,10 +54,28 @@ describe Order, type: :model do
       @order_1 = @customer.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
 
       @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
-      @order_1.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 3)
+      @fullfilled_pull_toys = @order_1.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 3)
     end
+
     it 'grandtotal' do
       expect(@order_1.grandtotal).to eq(230)
+    end
+
+    it 'cancel when no item_orders fulfilled' do
+      @order_1.cancel
+      expect(@order_1.status).to eq("cancelled")
+    end
+
+    it 'cancel when some item_orders fulfilled' do
+      expect(@pull_toy.inventory).to eq(32)
+
+      @fullfilled_pull_toys.fulfill
+      expect(@pull_toy.inventory).to eq(29)
+
+      @order_1.cancel
+      expect(@order_1.status).to eq("cancelled")
+      expect(@fullfilled_pull_toys.status).to eq("unfulfilled")
+      expect(@pull_toy.inventory).to eq(32)
     end
   end
 end


### PR DESCRIPTION
### Feature: Order Cancellation
    
When a user is logged in and has placed an order, they can now go to that order's show page and click a button to cancel the order.
    
When an order is cancelled:
- Each row in the item_orders table is given a status of 'unfulfilled'
- The order itself is given a status of 'cancelled'
- Item quantities in the order are restocked to the merchant inventory
    
The user will be returned to their profile and a flash message will say that the order is cancelled.
When the user visits that order page again, they will see the order status is cancelled.