### PR TITLE
Adds feature: Order Status will update to 'packaged' when all of its items are fulfilled

### DIFF
--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -13,6 +13,7 @@ class ItemOrder <ApplicationRecord
   def fulfill
     item.sell(quantity)
     update(status: "fulfilled")
+    order.pack if order.can_pack?
   end
 
   def unfulfill

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -17,4 +17,12 @@ class Order <ApplicationRecord
     end
     self.update(status: "cancelled")
   end
+
+  def can_pack?
+    item_orders.all?(&:fulfilled?)
+  end
+
+  def pack
+    self.update(status: "packaged") if can_pack?
+  end
 end

--- a/spec/features/orders/update_status_spec.rb
+++ b/spec/features/orders/update_status_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Order Status Update Spec" do
+  before :each do
+    @items = create_list(:item, 2)
+    @item1, @item2 = @items
+
+    @order1 = create(:order)
+    @order1.item_orders.create!(item: @item1, price: @item1.price, quantity: 1)
+    @order1.item_orders.create!(item: @item2, price: @item2.price, quantity: 1)
+    @order1 = Order.all.first
+  end
+
+  describe "As a registered user" do
+    describe "My Order Status can change" do
+      it "It is 'pending' if all items in the order are still unfulfilled" do
+        expect(@order1.item_orders.all?(&:unfulfilled?)).to be_truthy
+
+        visit "/profile/orders/#{@order1.id}"
+
+        expect(page).to have_content("Status: pending")
+      end
+      it "It is 'pending' if any items in the order are still unfulfilled" do
+        @order1.item_orders.first.fulfill
+
+        expect(@order1.item_orders.any?(&:unfulfilled?)).to be_truthy
+        expect(@order1.item_orders.any?(&:fulfilled?)).to be_truthy
+
+        visit "/profile/orders/#{@order1.id}"
+
+        expect(page).to have_content("Status: pending")
+      end
+      it "It is 'packaged' if all items in the order become fulfilled" do
+        @order1.item_orders.each(&:fulfill)
+        expect(@order1.item_orders.all?(&:fulfilled?)).to be_truthy
+
+        visit "/profile/orders/#{@order1.id}"
+        expect(page).to have_content("Status: packaged")
+      end
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -77,5 +77,24 @@ describe Order, type: :model do
       expect(@fullfilled_pull_toys.status).to eq("unfulfilled")
       expect(@pull_toy.inventory).to eq(32)
     end
+
+    it "only package when all item orders fulfilled" do
+      expect(@order_1.item_orders.size).to eq(2)
+      expect(@order_1.status).to eq("pending")
+
+      @order_1.item_orders.first.fulfill
+      expect(@order_1.item_orders.all?(&:fulfilled?)).to be_falsey
+      expect(@order_1.can_pack?).to be_falsey
+
+      @order_1.pack
+      expect(@order_1.status).to eq("pending")
+
+      @order_1.item_orders.last.fulfill
+      expect(@order_1.item_orders.all?(&:fulfilled?)).to be_truthy
+      expect(@order_1.can_pack?).to be_truthy
+
+      @order_1.pack
+      expect(@order_1.status).to eq("packaged")
+    end
   end
 end


### PR DESCRIPTION
Orders can be `packaged` when all the items are fulfilled.
If there are any unfulfilled items, the order cannot be `packaged` and will remain `pending`.