### PR TITLE
Merchant Index Page - User Stories 38 - 41 

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,7 @@
+class Admin::MerchantsController < ApplicationController
+
+  def index
+    @merchants = Merchant.all
+  end
+
+end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -7,7 +7,12 @@ class Admin::MerchantsController < ApplicationController
   def update
     merchant = Merchant.find(params[:merchant_id])
     merchant.change_status
-    flash[:disabled] = "You have now disabled #{merchant.name}"
+    merchant.change_active_status
+    if merchant.enabled?
+      flash[:enabled] = "You have now enabled #{merchant.name}"
+    else
+      flash[:disabled] = "You have now disabled #{merchant.name}"
+    end
     redirect_to "/admin/merchants"
   end
 

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -4,4 +4,11 @@ class Admin::MerchantsController < ApplicationController
     @merchants = Merchant.all
   end
 
+  def update
+    merchant = Merchant.find(params[:merchant_id])
+    merchant.change_status
+    flash[:disabled] = "You have now disabled #{merchant.name}"
+    redirect_to "/admin/merchants"
+  end
+
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -33,4 +33,14 @@ class Merchant <ApplicationRecord
     end
   end
 
+  def change_active_status
+    items.each do |item|
+      if item.active?
+        item.update(active?: "false")
+      else
+        item.update(active?: "true")
+      end
+    end
+  end
+
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -25,4 +25,12 @@ class Merchant <ApplicationRecord
     item_orders.distinct.joins(:order).pluck(:city)
   end
 
+  def change_status
+    if self.enabled?
+      self.update(enabled?: "false")
+    else
+      self.update(enabled?: "true")
+    end
+  end
+
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,0 +1,13 @@
+<h1 align = "center">Merchants</h1>
+<section class = "grid-container">
+  <% @merchants.each do |merchant|%>
+    <section class = "grid-item <%= "merchant-#{merchant.id}" %>">
+      <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
+      <% if merchant.enabled? %>
+      <%= link_to "DISABLE", "/admin/merchants/#{merchant.id}", method: :patch %>
+      <% else %>
+      <%= link_to "ENABLE", "/admin/merchants/#{merchant.id}", method: :patch %>
+      <% end %>
+    </section>
+  <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/dashboard", to: "dashboard#index"
     get "/merchants", to: "merchants#index"
+    patch "/merchants/:merchant_id", to: "merchants#update"
   end
 
   namespace :merchant do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get "/dashboard", to: "dashboard#index"
+    get "/merchants", to: "merchants#index"
   end
 
   namespace :merchant do

--- a/db/migrate/20200728173113_add_enabled_to_merchants.rb
+++ b/db/migrate/20200728173113_add_enabled_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddEnabledToMerchants < ActiveRecord::Migration[5.1]
+  def change
+    add_column :merchants, :enabled?, :boolean, default: true 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200725194353) do
+ActiveRecord::Schema.define(version: 20200728173113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20200725194353) do
     t.integer "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "enabled?", default: true
   end
 
   create_table "orders", force: :cascade do |t|

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -2,36 +2,29 @@ require 'rails_helper'
 
 RSpec.describe "Admin's Merchant Index Page"  do
   before(:each) do
-    @bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-    @dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
-    @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-    @pull_toy = @dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
-    @dog_bone = @dog_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+    @brian = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 21)
   end
 
-  it "Displays a 'disable' button next to any merchants who are not disabled and when the button is clicked, admin is returned to admin's merchant index page where there's a flash message that the merchant's account is now disabled" do
+  it "Displays a 'disable'/'enable' button next to the merchant and generates the corresponding flash message" do
     visit "/admin/merchants"
-    within ".merchant-#{@bike_shop.id}" do
+
+    within ".merchant-#{@brian.id}" do
       click_on "DISABLE"
       expect(current_path).to eq("/admin/merchants")
       expect(page).to_not have_link("DISABLE")
+      expect(page).to have_link("ENABLE")
     end
-    expect(page).to have_content("You have now disabled #{@bike_shop.name}")
+    expect(page).to have_content("You have now disabled #{@brian.name}")
+
+    within ".merchant-#{@brian.id}" do
+      click_on "ENABLE"
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to_not have_link("ENABLE")
+      expect(page).to have_link("DISABLE")
+    end
+    expect(page).to have_content("You have now enabled #{@brian.name}")
+
   end
+
 end
-
-# User Story 38, Admin disables a merchant account
-#
-# As an admin
-# When I visit the admin's merchant index page ('/admin/merchants')
-# I see a "disable" button next to any merchants who are not yet disabled
-# When I click on the "disable" button
-# I am returned to the admin's merchant index page where I see that the merchant's account is now disabled
-# And I see a flash message that the merchant's account is now disabled
-
-# User Story 39, Disabled Merchant Item's are inactive
-#
-# As an admin
-# When I visit the merchant index page
-# And I click on the "disable" button for an enabled merchant
-# Then all of that merchant's items should be deactivated

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -24,7 +24,23 @@ RSpec.describe "Admin's Merchant Index Page"  do
       expect(page).to have_link("DISABLE")
     end
     expect(page).to have_content("You have now enabled #{@brian.name}")
+  end
 
+  it "After clicking 'disable'/'enable' on a merchant, the merchant's items are deactivated/activated" do
+    expect(Merchant.find(@brian.id).items.all?(&:active?)).to be_truthy
+
+    visit "/admin/merchants"
+    within ".merchant-#{@brian.id}" do
+      click_on "DISABLE"
+    end
+
+    expect(Merchant.find(@brian.id).items.all?(&:active?)).to be_falsey
+
+    within ".merchant-#{@brian.id}" do
+      click_on "ENABLE"
+    end
+
+    expect(Merchant.find(@brian.id).items.all?(&:active?)).to be_truthy
   end
 
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe "Admin's Merchant Index Page"  do
+  before(:each) do
+    @bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+    @pull_toy = @dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
+    @dog_bone = @dog_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+  end
+
+  it "Displays a 'disable' button next to any merchants who are not disabled and when the button is clicked, admin is returned to admin's merchant index page where there's a flash message that the merchant's account is now disabled" do
+    visit "/admin/merchants"
+    within ".merchant-#{@bike_shop.id}" do
+      click_on "DISABLE"
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to_not have_link("DISABLE")
+    end
+    expect(page).to have_content("You have now disabled #{@bike_shop.name}")
+  end
+end
+
+# User Story 38, Admin disables a merchant account
+#
+# As an admin
+# When I visit the admin's merchant index page ('/admin/merchants')
+# I see a "disable" button next to any merchants who are not yet disabled
+# When I click on the "disable" button
+# I am returned to the admin's merchant index page where I see that the merchant's account is now disabled
+# And I see a flash message that the merchant's account is now disabled
+
+# User Story 39, Disabled Merchant Item's are inactive
+#
+# As an admin
+# When I visit the merchant index page
+# And I click on the "disable" button for an enabled merchant
+# Then all of that merchant's items should be deactivated

--- a/spec/features/navigation/navigation_404_spec.rb
+++ b/spec/features/navigation/navigation_404_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Navigation 404 Spec" do
       end
 
       it "/admin" do
-        visit admin_path
+        visit "/admin"
         expect(page).to have_content(@error_404)
 
         visit admin_dashboard_path
@@ -51,7 +51,7 @@ RSpec.describe "Navigation 404 Spec" do
       end
 
       it "/admin" do
-        visit admin_path
+        visit "/admin"
         expect(page).to have_content(@error_404)
 
         visit admin_dashboard_path
@@ -72,7 +72,7 @@ RSpec.describe "Navigation 404 Spec" do
       end
 
       it "/admin" do
-        visit admin_path
+        visit "/admin"
         expect(page).to have_content(@error_404)
 
         visit admin_dashboard_path

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -56,6 +56,7 @@ describe Item, type: :model do
 
       expect(@item1.total_sold).to eq(1)
     end
+
   end
 
   describe 'class methods' do
@@ -94,5 +95,5 @@ describe Item, type: :model do
     it '.most_popular_list' do
       expect(Item.most_popular_list).to eq([@item10, @item9, @item8, @item7, @item6])
     end
-    end
   end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -68,7 +68,7 @@ describe Merchant, type: :model do
     it "change_active_status" do
       expect(@meg.items.all?(&:active?)).to be_truthy
 
-      @meg.change_active
+      @meg.change_active_status
 
       expect(@meg.items.all?(&:active?)).to be_falsey
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -54,5 +54,16 @@ describe Merchant, type: :model do
       expect(@meg.distinct_cities).to include("Denver")
       expect(@meg.distinct_cities).to include("Hershey")
     end
+
+    it "change_status" do
+      expect(@meg.enabled?).to be_truthy
+
+      @meg.change_status
+      expect(@meg.enabled?).to be_falsey
+
+      @meg.change_status
+      expect(@meg.enabled?).to be_truthy
+    end
+
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -65,5 +65,13 @@ describe Merchant, type: :model do
       expect(@meg.enabled?).to be_truthy
     end
 
+    it "change_active_status" do
+      expect(@meg.items.all?(&:active?)).to be_truthy
+
+      @meg.change_active
+
+      expect(@meg.items.all?(&:active?)).to be_falsey
+    end
+
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -7,6 +7,8 @@ describe Merchant, type: :model do
     it { should validate_presence_of :city }
     it { should validate_presence_of :state }
     it { should validate_presence_of :zip }
+    it { should validate_inclusion_of(:enabled?).in_array([true,false]) }
+
   end
 
   describe "relationships" do
@@ -52,6 +54,5 @@ describe Merchant, type: :model do
       expect(@meg.distinct_cities).to include("Denver")
       expect(@meg.distinct_cities).to include("Hershey")
     end
-
   end
 end


### PR DESCRIPTION
User stories 38 & 40 were opposites from each other, as were 39 & 41. 

**38 & 40**
- focused on creating a disable/enable button 
- each merchant had either one (not both) at a time 
- once a merchant was disabled/enabled, a flash message was generated 

**39 & 41** 
- merchants items are deactivated/activated after clicking disable/enable button 
- there was no button to deactivate/activate (it automatically happened after disabling/enabling a merchant) 