### PR TITLE
Fix order pages

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -44,7 +44,11 @@ class OrdersController <ApplicationController
   end
 
   def retry_order_creation
-    flash[:notice] = "Please complete address form to create an order."
+    if current_user
+      flash[:notice] = "Please complete address form to create an order."
+    else
+      flash[:notice] = "Please login or register in order to checkout."
+    end 
     render :new
   end
 end

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -1,28 +1,39 @@
-<h1> Order ID: <%= @order.id %> for <%= @order.name %><h1>
+<h1 align = "center">Info for Order # <%= @order.id %> </h1>
+<h2 align = "center">Status: <%= @order.status %> </h2>
+<center>
+  <table>
+    <tr>
+      <th>Item</th>
+      <th>Description</th>
+      <th>Price</th>
+      <th>Quantity</th>
+      <th>Subtotal</th>
+    </tr>
+  <% @order.item_orders.each do |item_order|%>
+    <tr>
+    <section id = "item-<%=item_order.item_id%>">
+        <td>
+          <p><%=link_to item_order.item.name, "/items/#{item_order.item_id}"%></p>
+          <img src="<%= item_order.item.image %>" height="100" alt="Thumbnail Of: <%=item_order.item.name %>"/>
+        </td>
+        <td><p><%= item_order.item.description %></p></td>
+        <td><p><%= number_to_currency(item_order.price)%></p></td>
+        <td><p><%= item_order.quantity%></p></td>
+        <td><p><%= number_to_currency(item_order.subtotal)%></p></td>
+      </section>
+    </tr>
+  <% end %>
+</table>
 
-<p>
-  Order Date: <%= @order.created_at %>
-  Last Updated: <%= @order.updated_at %>
-  Status: <%= @order.status %>
-</p>
-
-<p>Total Items: <%= @order.items.sum('quantity') %><br>
-  Grand Total: <%= @order.grandtotal %></p>
-
-<h3>Items in this Order</h3>
-
-<% @order.items.each do |item| %>
-<section class=<%= "item-#{item.id}" %>>
-<ul>
-  <li><%= item.name %></li>
-  <li><%= item.description %></li>
-  <li><%= item.image %></li>
-  <li> <%= @order.item_orders.items_in_order_quantity(item) %></li>
-  <li> <%= @order.item_orders.item_order_subtotal(item) %></li>
-</ul>
-<% end %>
+<section id="grandtotal">
+  <p>Total Items: <%= @order.items.sum('quantity') %></p>
+  <p>Grand Total: <%=number_to_currency(@order.grandtotal)%></p>
+</section>
+<section id="orderdates">
+  <p>Order Date: <%= @order.created_at%></p>
+  <p>Last Updated: <%= @order.updated_at%></p>
 </section>
 
-<% if !@order.shipped? %>
+<% unless @order.shipped? %>
   <%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %>
 <% end %>

--- a/spec/features/orders/user_order_show_spec.rb
+++ b/spec/features/orders/user_order_show_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'As a registered user' do
 
     it "shows all order information, including order ID, order date, date of last update, current status" do
       visit "/profile/orders/#{@order1.id}"
-      expect(page).to have_content("Order ID: #{@order1.id}")
+      expect(page).to have_content("Info for Order # #{@order1.id}")
       expect(page).to have_content("Order Date: #{@order1.created_at}")
       expect(page).to have_content("Last Updated: #{@order1.updated_at}")
       expect(page).to have_content("Status: #{@order1.status}")
@@ -69,10 +69,11 @@ RSpec.describe 'As a registered user' do
 
     it "also shows each item in the order, including item name, description, thumbnail image, quantity, price and subtotal" do
       visit "/profile/orders/#{@order1.id}"
-      within("section.item-#{@items1.first.id}") do
+      within("section#item-#{@items1.first.id}") do
         expect(page).to have_content(@items1.first.name)
         expect(page).to have_content(@items1.first.description)
-        expect(page).to have_content(@items1.first.image)
+        expect(page).to have_css("img[src*='#{@items1.first.image}']")
+        expect(page).to have_css("img[alt='Thumbnail Of: #{@items1.first.name}']")
         expect(page).to have_content(@order1.item_orders.items_in_order_quantity(@items1.first))
         expect(page).to have_content(@order1.item_orders.item_order_subtotal(@items1.first))
       end
@@ -81,7 +82,7 @@ RSpec.describe 'As a registered user' do
     it "also shows the total quantity of items in the order as well as the grand total of all items in that order" do
       visit "/profile/orders/#{@order1.id}"
       expect(page).to have_content("Total Items: #{@order1.items.sum('quantity')}")
-      expect(page).to have_content("Grand Total: #{@order1.grandtotal}")
+      expect(page).to have_content("Grand Total: $500.00")
     end
   end
 end


### PR DESCRIPTION
![Before](https://user-images.githubusercontent.com/60243690/88870774-d207f000-d1db-11ea-9845-adac5e83f91f.png)
![After](https://user-images.githubusercontent.com/60243690/88870920-3c209500-d1dc-11ea-8d43-a82281f4fee0.png)


We tried to organize the user order show page so that it looked more readable for the viewer. We also updated order creation sad path to handle visitors that not logged in. 