### PR TITLE
Edit admin navigation bar 

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,11 @@
   <body>
     <nav class = "topnav">
       <%= link_to "Home", "/" %>
-      <%= link_to "All Merchants", "/merchants" %>
+      <% if  current_user && current_user.admin? %>
+        <%= link_to "All Merchants", "/admin/merchants" %>
+      <% else  %>
+        <%= link_to "All Merchants", "/merchants" %>
+      <% end %>
       <%= link_to "All Items", "/items" %>
       <% if current_user && current_user.regular? %>
         <%= link_to "Cart: #{cart.total_items}", "/cart" %>

--- a/spec/features/navigation/navigation_spec.rb
+++ b/spec/features/navigation/navigation_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe 'Site Navigation' do
       expect(page).to have_link("My Dashboard")
       expect(page).to have_link("All Users")
       expect(page).to have_link("Log Out")
+      expect(page).to have_link("All Merchants", href: "/admin/merchants")
       expect(page).to_not have_link("Log In")
       expect(page).to_not have_link("Register")
       expect(page).to_not have_link("Cart")


### PR DESCRIPTION
We updated the nav bar so that when admins are logged in, they go to `/admin/merchants` instead of `/merchants`