### PR TITLE
Admin user index

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,10 @@
 class Admin::UsersController < ApplicationController
   before_action :require_authorized_user
 
+  def index
+    @users = User.all
+  end
+
   def show
     @user = User.find(params[:id])
   end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,4 @@
 <h1>All Users</h1>
 <% @users.each do |user| %>
-  <%= link_to "#{user.name}" %>
+  <%= link_to "#{user.name}", "/admin/users/#{user.id}" %>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,4 @@
+<h1>All Users</h1>
+<% @users.each do |user| %>
+  <%= link_to "#{user.name}" %>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,1 +1,3 @@
 <h1>Viewing <%= @user.name %>'s User Profile</h1>
+<p>User type: <%= @user.role %></p>
+<p>Registered on: <%= @user.created_at %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/dashboard", to: "dashboard#index"
     get "/", to: "dashboard#index"
-    # remove "/dashboard" route if extra time
+    get "/users", to: "users#index"
     get "/users/:id", to: "users#show"
     patch "/:id", to: "orders#update"
     get "/merchants", to: "merchants#index"
@@ -63,7 +63,6 @@ Rails.application.routes.draw do
   namespace :merchant do
     get "/dashboard", to: "dashboard#index"
     get "/", to: "dashboard#index"
-    # remove "/dashboard" route if extra time
     get "/orders/:order_id", to: "orders#show"
     get "/items", to: "items#index"
   end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe "Admin user index page" do
     visit "/admin/users"
     click_on "#{@regular_user.name}"
     expect(current_path).to eq("/admin/users/#{@regular_user.id}")
+    expect(page).to have_content("Viewing #{@regular_user.name}'s User Profile")
     expect(page).to have_content("User type: #{@regular_user.role}")
-    expect(page).to have_content("Registered on: #{@regular_user.created_on}")
+    expect(page).to have_content("Registered on: #{@regular_user.created_at}")
   end
 end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe "Admin user index page" do
     visit "/"
     within('nav') do
       click_on "All Users"
-      expect(current_path).to eq("/admin/users")
     end
+    expect(current_path).to eq("/admin/users")
     expect(page).to have_content(@regular_user.name)
     expect(page).to have_content(@merchant_employee.name)
+    expect(page).to have_content(@admin.name)
   end
 
   it "Only admin users can access this users index page" do
@@ -32,9 +33,7 @@ RSpec.describe "Admin user index page" do
       which displays the user's registration date and the type of user" do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
     visit "/admin/users"
-    within("#user-#{@regular_user}") do
-      click_on "#{@regular_user.name}"
-    end
+    click_on "#{@regular_user.name}"
     expect(current_path).to eq("/admin/users/#{@regular_user.id}")
     expect(page).to have_content("User type: #{@regular_user.role}")
     expect(page).to have_content("Registered on: #{@regular_user.created_on}")

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Admin user index page" do
 
   it "There is a users link in my nav that routes me to a users index page" do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    visit "/"
     within('nav') do
       click_on "All Users"
       expect(current_path).to eq("/admin/users")

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "Admin user index page" do
+  before :each do
+    @admin = create(:user, role: 2)
+    @regular_user = create(:user)
+    @merchant_employee = create(:user, role: 1)
+    @error_404 = "The page you were looking for doesn't exist."
+  end
+
+  it "There is a users link in my nav that routes me to a users index page" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    within('nav') do
+      click_on "All Users"
+      expect(current_path).to eq("/admin/users")
+    end
+    expect(page).to have_content(@regular_user.name)
+    expect(page).to have_content(@merchant_employee.name)
+  end
+
+  it "Only admin users can access this users index page" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@customer)
+    visit "/admin/users"
+    expect(page).to have_content(@error_404)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_employee)
+    expect(page).to have_content(@error_404)
+  end
+
+  it "This page lists all users in the system, where a user's name links to their user show page,
+      which displays the user's registration date and the type of user" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    visit "/admin/users"
+    within("#user-#{@regular_user}") do
+      click_on "#{@regular_user.name}"
+    end
+    expect(current_path).to eq("/admin/users/#{@regular_user.id}")
+    expect(page).to have_content("User type: #{@regular_user.role}")
+    expect(page).to have_content("Registered on: #{@regular_user.created_on}")
+  end
+end


### PR DESCRIPTION
Completes user story 53 (issue #101 )
• An admin user can visit a users index page that displays a list of all users in the system - this page renders a 404 error when accessed by users who are not admins
• The name of each user listed in on the admin's users index page links to their respective admin user show page
• User show pages display the user's role and when they registered their account