### PR TITLE
Fixed the admin 'ship' button - it was not working

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -6,7 +6,7 @@
       <p>Order placed on: <%= order.created_at %></p>
       <p>Order status: <%= order.status %></p>
       <% if order.packaged? %>
-        <%= button_to "Ship", "admin/#{order.id}", method: :patch %>
+        <%= button_to 'Ship', "/admin/orders/#{order.id}", :controller =>'admin/orders_controller',:action => 'update',:method => :patch %>
       <% end %>
     </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
     get "/", to: "dashboard#index"
     get "/users", to: "users#index"
     get "/users/:id", to: "users#show"
-    patch "/:id", to: "orders#update"
+    patch "/orders/:id", to: "orders#update"
     get "/merchants", to: "merchants#index"
     patch "/merchants/:merchant_id", to: "merchants#update"
     get "/merchants/:merchant_id", to: "merchants#show"


### PR DESCRIPTION
There is an issue when the admin tries to ship an order:
the request `patch` tries to route to `admin/admin/:order_id` and it is not working on Heroku

We changed it to route to the admin/order#update instead.
It's tested and it works! This PR will fix the bug on Heroku.