### PR TITLE
Remove image url validation from Item model

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,6 @@ class Item <ApplicationRecord
   validates_presence_of :name,
                         :description,
                         :price,
-                        :image,
                         :inventory
 
   validates :price, :numericality => { :greater_than => 0}

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,7 +5,6 @@ describe Item, type: :model do
     it { should validate_presence_of :name }
     it { should validate_presence_of :description }
     it { should validate_presence_of :price }
-    it { should validate_presence_of :image }
     it { should validate_presence_of :inventory }
     it { should validate_inclusion_of(:active?).in_array([true,false]) }
   end


### PR DESCRIPTION
This way, the default image placeholder can work.
It wasn't working on Heroku - now it should.